### PR TITLE
Add spinner and upload size when uploading images

### DIFF
--- a/cmd/kp/main.go
+++ b/cmd/kp/main.go
@@ -5,6 +5,8 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
+	"log"
 	"os"
 
 	"github.com/pivotal/kpack/pkg/logs"
@@ -25,6 +27,7 @@ import (
 	"github.com/pivotal/build-service-cli/pkg/image"
 	importpkg "github.com/pivotal/build-service-cli/pkg/import"
 	"github.com/pivotal/build-service-cli/pkg/k8s"
+	"github.com/pivotal/build-service-cli/pkg/registry"
 	"github.com/pivotal/build-service-cli/pkg/secret"
 	"github.com/pivotal/build-service-cli/pkg/source"
 )
@@ -35,6 +38,8 @@ var (
 )
 
 func main() {
+	log.SetOutput(ioutil.Discard)
+
 	var clientSetProvider k8s.DefaultClientSetProvider
 
 	rootCmd := &cobra.Command{
@@ -175,8 +180,8 @@ func getBuilderCommand(clientSetProvider k8s.ClientSetProvider) *cobra.Command {
 
 func getStackCommand(clientSetProvider k8s.ClientSetProvider) *cobra.Command {
 	stackFactory := &clusterstack.Factory{
-		Fetcher:   &image.Fetcher{},
-		Relocator: &image.Relocator{},
+		Fetcher:   &registry.Fetcher{},
+		Relocator: &registry.Relocator{},
 	}
 
 	stackRootCmd := &cobra.Command{
@@ -188,7 +193,7 @@ func getStackCommand(clientSetProvider k8s.ClientSetProvider) *cobra.Command {
 		clusterstackcmds.NewCreateCommand(clientSetProvider, stackFactory),
 		clusterstackcmds.NewListCommand(clientSetProvider),
 		clusterstackcmds.NewStatusCommand(clientSetProvider),
-		clusterstackcmds.NewUpdateCommand(clientSetProvider, &image.Fetcher{}, &image.Relocator{}),
+		clusterstackcmds.NewUpdateCommand(clientSetProvider, &registry.Fetcher{}, &registry.Relocator{}),
 		clusterstackcmds.NewDeleteCommand(clientSetProvider),
 	)
 	return stackRootCmd
@@ -196,8 +201,8 @@ func getStackCommand(clientSetProvider k8s.ClientSetProvider) *cobra.Command {
 
 func getStoreCommand(clientSetProvider k8s.ClientSetProvider) *cobra.Command {
 	bpUploader := &buildpackage.Uploader{
-		Fetcher:   &image.Fetcher{},
-		Relocator: &image.Relocator{},
+		Fetcher:   &registry.Fetcher{},
+		Relocator: &registry.Relocator{},
 	}
 
 	factory := &clusterstore.Factory{Uploader: bpUploader}
@@ -220,13 +225,13 @@ func getStoreCommand(clientSetProvider k8s.ClientSetProvider) *cobra.Command {
 
 func getImportCommand(clientSetProvider k8s.ClientSetProvider) *cobra.Command {
 	stackFactory := &clusterstack.Factory{
-		Fetcher:   &image.Fetcher{},
-		Relocator: &image.Relocator{},
+		Fetcher:   &registry.Fetcher{},
+		Relocator: &registry.Relocator{},
 	}
 
 	bpUploader := &buildpackage.Uploader{
-		Fetcher:   &image.Fetcher{},
-		Relocator: &image.Relocator{},
+		Fetcher:   &registry.Fetcher{},
+		Relocator: &registry.Relocator{},
 	}
 
 	storeFactory := &clusterstore.Factory{Uploader: bpUploader}

--- a/pkg/buildpackage/uploader.go
+++ b/pkg/buildpackage/uploader.go
@@ -4,6 +4,7 @@
 package buildpackage
 
 import (
+	"io"
 	"io/ioutil"
 	"os"
 	"path"
@@ -22,7 +23,7 @@ const (
 )
 
 type Relocator interface {
-	Relocate(image v1.Image, dest string) (string, error)
+	Relocate(writer io.Writer, image v1.Image, dest string) (string, error)
 }
 
 type Fetcher interface {
@@ -34,7 +35,7 @@ type Uploader struct {
 	Fetcher   Fetcher
 }
 
-func (u *Uploader) Upload(repository, buildPackage string) (string, error) {
+func (u *Uploader) UploadBuildpackage(writer io.Writer, repository, buildPackage string) (string, error) {
 	tempDir, err := ioutil.TempDir("", "cnb-upload")
 	if err != nil {
 		return "", err
@@ -56,7 +57,7 @@ func (u *Uploader) Upload(repository, buildPackage string) (string, error) {
 		return "", err
 	}
 
-	return u.Relocator.Relocate(image, path.Join(repository, strings.ReplaceAll(metadata.Id, "/", "_")))
+	return u.Relocator.Relocate(writer, image, path.Join(repository, strings.ReplaceAll(metadata.Id, "/", "_")))
 }
 
 func (u *Uploader) read(buildPackage, tempDir string) (v1.Image, error) {

--- a/pkg/buildpackage/uploader_test.go
+++ b/pkg/buildpackage/uploader_test.go
@@ -5,6 +5,7 @@ package buildpackage
 
 import (
 	"fmt"
+	"io/ioutil"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/v1/random"
@@ -31,7 +32,7 @@ func testBuildpackageUploader(t *testing.T, when spec.G, it spec.S) {
 	when("cnb file is provided", func() {
 		it("it uploads to registry", func() {
 
-			image, err := uploader.Upload("kpackcr.org/somepath", "testdata/sample-bp.cnb")
+			image, err := uploader.UploadBuildpackage(ioutil.Discard, "kpackcr.org/somepath", "testdata/sample-bp.cnb")
 			require.NoError(t, err)
 
 			const expectedFixture = "kpackcr.org/somepath/sample_buildpackage@sha256:37d646bec2453ab05fe57288ede904dfd12f988dbc964e3e764c41c1bd3b58bf"
@@ -49,7 +50,7 @@ func testBuildpackageUploader(t *testing.T, when spec.G, it spec.S) {
 
 			fetcher.AddImage("some/remote-bp", testImage)
 
-			image, err := uploader.Upload("kpackcr.org/somepath", "some/remote-bp")
+			image, err := uploader.UploadBuildpackage(ioutil.Discard, "kpackcr.org/somepath", "some/remote-bp")
 			require.NoError(t, err)
 
 			digest, err := testImage.Digest()

--- a/pkg/clusterstore/fakes/fake_uploader.go
+++ b/pkg/clusterstore/fakes/fake_uploader.go
@@ -3,11 +3,15 @@
 
 package fakes
 
-import "github.com/pkg/errors"
+import (
+	"io"
+
+	"github.com/pkg/errors"
+)
 
 type FakeBuildpackageUploader map[string]string
 
-func (f FakeBuildpackageUploader) Upload(_ string, buildpackage string) (string, error) {
+func (f FakeBuildpackageUploader) UploadBuildpackage(w io.Writer, _ string, buildpackage string) (string, error) {
 	uploadedImage, ok := f[buildpackage]
 	if !ok {
 		return "", errors.Errorf("could not upload %s", buildpackage)

--- a/pkg/commands/clusterstack/create.go
+++ b/pkg/commands/clusterstack/create.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/pivotal/build-service-cli/pkg/clusterstack"
+	"github.com/pivotal/build-service-cli/pkg/commands"
 	"github.com/pivotal/build-service-cli/pkg/k8s"
 )
 
@@ -39,6 +40,7 @@ kp clusterstack create my-stack --build-image ../path/to/build.tar --run-image .
 				return err
 			}
 
+			factory.Printer = commands.NewPrinter(cmd)
 			stack, err := factory.MakeStack(args[0])
 			if err != nil {
 				return err

--- a/pkg/commands/clusterstore/add.go
+++ b/pkg/commands/clusterstore/add.go
@@ -53,6 +53,7 @@ kp clusterstore add my-store -b ../path/to/my-local-buildpackage.cnb`,
 				return err
 			}
 
+			factory.Printer.Printf("Adding Buildpackages...")
 			updatedStore, storeUpdated, err := factory.AddToStore(s, repo, buildpackages...)
 			if err != nil {
 				return err

--- a/pkg/commands/clusterstore/add_test.go
+++ b/pkg/commands/clusterstore/add_test.go
@@ -106,7 +106,7 @@ func testClusterStoreAddCommand(t *testing.T, when spec.G, it spec.S) {
 					},
 				},
 			},
-			ExpectedOutput: "Uploading to 'some-registry.io/some-repo'...\nAdded Buildpackage 'some/path/newbp@sha256:123newbp'\nAdded Buildpackage 'some/path/bpfromcnb@sha256:123imagefromcnb'\nClusterStore Updated\n",
+			ExpectedOutput: "Adding Buildpackages...\n\tAdded Buildpackage\n\tAdded Buildpackage\nClusterStore Updated\n",
 		}.TestK8sAndKpack(t, cmdFunc)
 	})
 
@@ -123,7 +123,7 @@ func testClusterStoreAddCommand(t *testing.T, when spec.G, it spec.S) {
 				"-b", "some/imageAlreadyInStore",
 			},
 			ExpectErr:      false,
-			ExpectedOutput: "Uploading to 'some-registry.io/some-repo'...\nBuildpackage 'some/path/imageInStoreDifferentPath@sha256:123alreadyInStore' already exists in the store\nClusterStore Unchanged\n",
+			ExpectedOutput: "Adding Buildpackages...\n\tBuildpackage already exists in the store\nClusterStore Unchanged\n",
 		}.TestK8sAndKpack(t, cmdFunc)
 	})
 

--- a/pkg/commands/clusterstore/create.go
+++ b/pkg/commands/clusterstore/create.go
@@ -45,6 +45,7 @@ kp clusterstore create my-store -b ../path/to/my-local-buildpackage.cnb`,
 				return err
 			}
 
+			factory.Printer.Printf("Creating Cluster Store...")
 			newStore, err := factory.MakeStore(name, buildpackages...)
 			if err != nil {
 				return err

--- a/pkg/commands/clusterstore/create_test.go
+++ b/pkg/commands/clusterstore/create_test.go
@@ -87,7 +87,7 @@ func testClusterStoreCreateCommand(t *testing.T, when spec.G, it spec.S) {
 				"--buildpackage", buildpackage1,
 				"-b", buildpackage2,
 			},
-			ExpectedOutput: "Uploading to 'some-registry.io/some-repo'...\n\"test-store\" created\n",
+			ExpectedOutput: "Creating Cluster Store...\n\"test-store\" created\n",
 			ExpectCreates: []runtime.Object{
 				expectedStore,
 			},
@@ -140,7 +140,7 @@ func testClusterStoreCreateCommand(t *testing.T, when spec.G, it spec.S) {
 				expectedStore.Name,
 			},
 			ExpectErr:      true,
-			ExpectedOutput: "Error: At least one buildpackage must be provided\n",
+			ExpectedOutput: "Creating Cluster Store...\nError: At least one buildpackage must be provided\n",
 		}.TestK8sAndKpack(t, cmdFunc)
 	})
 }

--- a/pkg/commands/import/import.go
+++ b/pkg/commands/import/import.go
@@ -201,6 +201,7 @@ func (i importHelper) ImportStacks(factory *clusterstack.Factory) error {
 	for _, stack := range i.descriptor.Stacks {
 		i.logger.Printf("Importing Cluster Stack '%s'...", stack.Name)
 
+		factory.Printer = i.logger
 		factory.BuildImageRef = stack.BuildImage.Image // FIXME
 		factory.RunImageRef = stack.RunImage.Image     // FIXME
 

--- a/pkg/commands/import/import_test.go
+++ b/pkg/commands/import/import_test.go
@@ -177,7 +177,7 @@ func testImportCommand(t *testing.T, when spec.G, it spec.S) {
 				Args: []string{
 					"-f", "./testdata/deps.yaml",
 				},
-				ExpectedOutput: "Importing Cluster Store 'some-store'...\nUploading to 'new-registry.io/new-project'...\nImporting Cluster Stack 'some-stack'...\nImporting Cluster Stack 'default'...\nImporting Cluster Builder 'some-ccb'...\nImporting Cluster Builder 'default'...\n",
+				ExpectedOutput: "Importing Cluster Store 'some-store'...\nImporting Cluster Stack 'some-stack'...\nImporting Cluster Stack 'default'...\nImporting Cluster Builder 'some-ccb'...\nImporting Cluster Builder 'default'...\n",
 				ExpectCreates: []runtime.Object{
 					store,
 					stack,
@@ -233,7 +233,7 @@ func testImportCommand(t *testing.T, when spec.G, it spec.S) {
 					Args: []string{
 						"-f", "./testdata/deps.yaml",
 					},
-					ExpectedOutput: "Importing Cluster Store 'some-store'...\nUploading to 'new-registry.io/new-project'...\nBuildpackage 'new-registry.io/new-project/store-image@sha256:123abc' already exists in the store\nImporting Cluster Stack 'some-stack'...\nImporting Cluster Stack 'default'...\nImporting Cluster Builder 'some-ccb'...\nImporting Cluster Builder 'default'...\n",
+					ExpectedOutput: "Importing Cluster Store 'some-store'...\n\tBuildpackage already exists in the store\nImporting Cluster Stack 'some-stack'...\nImporting Cluster Stack 'default'...\nImporting Cluster Builder 'some-ccb'...\nImporting Cluster Builder 'default'...\n",
 					ExpectUpdates: []clientgotesting.UpdateActionImpl{
 						{
 							Object: expectedStore,
@@ -279,7 +279,7 @@ func testImportCommand(t *testing.T, when spec.G, it spec.S) {
 					Args: []string{
 						"-f", "./testdata/deps.yaml",
 					},
-					ExpectedOutput: "Importing Cluster Store 'some-store'...\nUploading to 'new-registry.io/new-project'...\nBuildpackage 'new-registry.io/new-project/store-image@sha256:123abc' already exists in the store\nImporting Cluster Stack 'some-stack'...\nImporting Cluster Stack 'default'...\nImporting Cluster Builder 'some-ccb'...\nImporting Cluster Builder 'default'...\n",
+					ExpectedOutput: "Importing Cluster Store 'some-store'...\n\tBuildpackage already exists in the store\nImporting Cluster Stack 'some-stack'...\nImporting Cluster Stack 'default'...\nImporting Cluster Builder 'some-ccb'...\nImporting Cluster Builder 'default'...\n",
 					ExpectUpdates: []clientgotesting.UpdateActionImpl{
 						{
 							Object: expectedStore,
@@ -369,7 +369,7 @@ func testImportCommand(t *testing.T, when spec.G, it spec.S) {
 					Args: []string{
 						"-f", "./testdata/updated-deps.yaml",
 					},
-					ExpectedOutput: "Importing Cluster Store 'some-store'...\nUploading to 'new-registry.io/new-project'...\nAdded Buildpackage 'new-registry.io/new-project/store-image-2@sha256:456def'\nImporting Cluster Stack 'some-stack'...\nImporting Cluster Stack 'default'...\nImporting Cluster Builder 'some-ccb'...\nImporting Cluster Builder 'default'...\n",
+					ExpectedOutput: "Importing Cluster Store 'some-store'...\n\tAdded Buildpackage\nImporting Cluster Stack 'some-stack'...\nImporting Cluster Stack 'default'...\nImporting Cluster Builder 'some-ccb'...\nImporting Cluster Builder 'default'...\n",
 					ExpectUpdates: []clientgotesting.UpdateActionImpl{
 						{
 							Object: expectedStore,

--- a/pkg/commands/printer.go
+++ b/pkg/commands/printer.go
@@ -12,16 +12,16 @@ import (
 
 func NewPrinter(cmd *cobra.Command) *Logger {
 	return &Logger{
-		Out: cmd.OutOrStdout(),
-		Err: cmd.OutOrStderr(),
+		Writer: cmd.OutOrStdout(),
+		Err:    cmd.OutOrStderr(),
 	}
 }
 
 type Logger struct {
-	Out io.Writer
+	io.Writer
 	Err io.Writer
 }
 
 func (l *Logger) Printf(format string, a ...interface{}) {
-	l.Out.Write([]byte(fmt.Sprintf(format+"\n", a...)))
+	l.Write([]byte(fmt.Sprintf(format+"\n", a...)))
 }

--- a/pkg/image/fakes/fake_relocator.go
+++ b/pkg/image/fakes/fake_relocator.go
@@ -5,6 +5,7 @@ package fakes
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -13,7 +14,7 @@ import (
 type Relocator struct {
 }
 
-func (r *Relocator) Relocate(image v1.Image, dest string) (string, error) {
+func (r *Relocator) Relocate(_ io.Writer, image v1.Image, dest string) (string, error) {
 	digest, err := image.Digest()
 	if err != nil {
 		return "", err

--- a/pkg/registry/errors.go
+++ b/pkg/registry/errors.go
@@ -1,7 +1,7 @@
 // Copyright 2020-Present VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package image
+package registry
 
 import (
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"

--- a/pkg/registry/fetcher.go
+++ b/pkg/registry/fetcher.go
@@ -1,7 +1,7 @@
 // Copyright 2020-Present VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package image
+package registry
 
 import (
 	"os"

--- a/pkg/registry/relocator.go
+++ b/pkg/registry/relocator.go
@@ -1,10 +1,11 @@
 // Copyright 2020-Present VMware, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-package image
+package registry
 
 import (
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -17,7 +18,7 @@ import (
 type Relocator struct {
 }
 
-func (*Relocator) Relocate(image v1.Image, dest string) (string, error) {
+func (*Relocator) Relocate(writer io.Writer, image v1.Image, dest string) (string, error) {
 	ref, err := name.ParseReference(dest, name.WeakValidation)
 	if err != nil {
 		return "", errors.WithStack(err)
@@ -29,14 +30,24 @@ func (*Relocator) Relocate(image v1.Image, dest string) (string, error) {
 		return "", errors.WithStack(err)
 	}
 
-	err = remote.Write(ref, image, remote.WithAuthFromKeychain(authn.DefaultKeychain))
-	if err != nil {
-		return "", newImageAccessError(refName, err)
-	}
-
 	digest, err := image.Digest()
 	if err != nil {
 		return "", errors.WithStack(err)
+	}
+
+	size, err := imageSize(image)
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+
+	writer.Write([]byte(fmt.Sprintf("\tUploading '%s@%s'", ref, digest)))
+	spinner := newUploadSpinner(writer, size)
+	defer spinner.Stop()
+	go spinner.Write()
+
+	err = remote.Write(ref, image, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	if err != nil {
+		return "", newImageAccessError(refName, err)
 	}
 
 	return fmt.Sprintf("%s@%s", refName, digest.String()), remote.Tag(ref.Context().Tag(timestampTag()), image, remote.WithAuthFromKeychain(authn.DefaultKeychain))
@@ -45,4 +56,26 @@ func (*Relocator) Relocate(image v1.Image, dest string) (string, error) {
 func timestampTag() string {
 	now := time.Now()
 	return fmt.Sprintf("%s%02d%02d%02d", now.Format("20060102"), now.Hour(), now.Minute(), now.Second())
+}
+
+func imageSize(image v1.Image) (int64, error) {
+	size, err := image.Size()
+	if err != nil {
+		return 0, err
+	}
+
+	layers, err := image.Layers()
+	if err != nil {
+		return 0, err
+	}
+
+	for _, layer := range layers {
+		layerSize, err := layer.Size()
+		if err != nil {
+			return 0, err
+		}
+
+		size += layerSize
+	}
+	return size, nil
 }

--- a/pkg/registry/spinner.go
+++ b/pkg/registry/spinner.go
@@ -1,0 +1,94 @@
+// Copyright 2020-Present VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0	// SPDX-License-Identifier: Apache-2.0
+
+package registry
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"syscall"
+	"time"
+
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+const framerate = time.Millisecond * 150
+
+var spinners = []string{"|", "/", "-", "\\"}
+
+type uploadSpinner struct {
+	size     string
+	stopChan chan struct{}
+	doneChan chan struct{}
+	Output   io.Writer
+	NotTty   bool
+}
+
+func newUploadSpinner(writer io.Writer, size int64) *uploadSpinner {
+	sp := &uploadSpinner{
+		size:     readableSize(size),
+		stopChan: make(chan struct{}),
+		doneChan: make(chan struct{}),
+		Output:   writer,
+		NotTty:   !terminal.IsTerminal(syscall.Stdout),
+	}
+	return sp
+}
+
+func (s *uploadSpinner) Stop() {
+	close(s.stopChan)
+	<-s.doneChan
+}
+
+func (s *uploadSpinner) Write() {
+	defer close(s.doneChan)
+
+	if s.NotTty {
+		return
+	}
+
+	index := 0
+	fmt.Fprint(s.Output, "\n")
+	for {
+		select {
+		case <-s.stopChan:
+			s.clear()
+			return
+		case <-time.After(framerate):
+			s.clear()
+
+			fmt.Fprintf(s.Output, "\t %s %s", spinners[index], s.size)
+
+			index++
+			if index == len(spinners) {
+				index = 0
+			}
+		}
+	}
+}
+
+func (s *uploadSpinner) clear() {
+	fmt.Fprint(s.Output, "\033[2K")
+	fmt.Fprint(s.Output, "\n")
+	fmt.Fprint(s.Output, "\033[1A")
+}
+
+func readableSize(length int64) string {
+	const (
+		gb = 1000000000
+		mb = 1000000
+		kb = 1000
+	)
+
+	switch {
+	case length > gb:
+		return fmt.Sprintf("%0.2f GB", float64(length)/gb)
+	case length > mb:
+		return fmt.Sprintf("%0.2f MB", float64(length)/mb)
+	case length > kb:
+		return fmt.Sprintf("%0.2f KB", float64(length)/kb)
+	default:
+		return strconv.FormatInt(length, 10) + " B"
+	}
+}


### PR DESCRIPTION
- Spinner will show uploaded image size
- Refactor BuildpackageUploader Signature to differentiate it from other uploaders
- Tab indent upload/import information to create a hierarchy of information